### PR TITLE
don't install the virtualenv in the project root

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,8 +20,7 @@
                     "editor.codeActionsOnSave": {
                         "source.organizeImports": true
                     }
-                },
-                "ruff.enableExperimentalFormatter": true
+                }
             },
             "extensions": [
 				"ms-python.python",

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,10 +1,12 @@
 #! /usr/bin/env bash
 
-WORKSPACE_DIR="$(pwd)"
 
-poetry config cache-dir "${WORKSPACE_DIR}/.cache"
-poetry config virtualenvs.in-project true
+POETRY_ROOT_DIR="$HOME/.poetry-root"
+mkdir "$POETRY_ROOT_DIR"
+
+poetry config cache-dir "${POETRY_ROOT_DIR}/.cache"
+poetry config virtualenvs.in-project false
 
 poetry install
 
-echo 'done installing dependencies!'
+echo 'Done installing dependencies!'

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-in-project=true


### PR DESCRIPTION
switching between the vscode dev container (which creates the venv with linux metadata and the file structure of the linux docker container) and my own osx command line kept blowing away the virtualenvs in strange ways. This should eliminate that source of thrashing.