### PR TITLE
parse the pico remote name correctly

### DIFF
--- a/src/pico_to_mqtt/caseta/topology.py
+++ b/src/pico_to_mqtt/caseta/topology.py
@@ -67,7 +67,7 @@ class Topology:
                 for button in remote_buttons
             }
 
-            device_name = device["name"].removesuffix("_Pico")
+            (_ignored, device_name) = device["name"].split('_')
             area_name = all_areas[device["area"]]["name"]
             device_id_as_int = int(device_id)
             if device["type"] in PicoRemoteType.values():

--- a/tests/caseta/test_topology.py
+++ b/tests/caseta/test_topology.py
@@ -9,11 +9,14 @@ from pico_to_mqtt.caseta.topology import Topology
 from pylutron_caseta.smartbridge import Smartbridge
 from pytest_mock import MockerFixture
 
+_AREA_ID = "99"
+_AREA_NAME = "fancyroom"
+_REMOTE_NAME = "entrywayremote"
 _SMARTBRIDGE_DEVICES = {
     "2": {
         "device_id": "2",
-        "name": "test_remote",
-        "area": "99",
+        "name": f"{_AREA_NAME}_{_REMOTE_NAME}",
+        "area": _AREA_ID,
         "type": PicoRemoteType.PICO_THREE_BUTTON_RAISE_LOWER.value,
     },
     "1": {"device_id": "1", "name": "Smart Bridge", "type": "SmartBridge"},
@@ -28,7 +31,7 @@ _SMARTBRIDGE_BUTTONS = {
     "104": {"device_id": "104", "button_number": 4, "parent_device": "2"},
 }
 
-_SMARTBRIDGE_AREAS = {"99": {"id": "99", "name": "fancyroom"}}
+_SMARTBRIDGE_AREAS = {"99": {"id": "99", "name": _AREA_NAME}}
 
 
 @pytest.fixture


### PR DESCRIPTION
the pico remote name values are in the form of
```
<area_name>_<remote_name> 
```
(underscores are not allowed in either area_name or remote_name). The default remote name is "Pico".

this change lets us parse the remote name out of the API response correctly