### PR TITLE
Dynamic topology updating

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,6 @@
         "vscode": {
             "settings": {
                 "editor.formatOnSave": true,
-                // "python.analysis.extraPaths": [
-                // ],
                 "editor.defaultFormatter": "charliermarsh.ruff",
                 "extensions.autoUpdate": false,
                 "python.defaultInterpreterPath": "/home/vscode/.poetry-root/.cache/virtualenvs/pico-to-mqtt/bin/python",
@@ -20,7 +18,7 @@
                 "python.analysis.stubPath": "typings",
                 "[python]": {
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": true
+                        "source.organizeImports": "explicit"
                     }
                 }
             },

--- a/src/pico_to_mqtt/caseta/model.py
+++ b/src/pico_to_mqtt/caseta/model.py
@@ -86,8 +86,12 @@ class PicoRemoteType(StrEnum):
         match str_literal:
             case cls.PICO_THREE_BUTTON_RAISE_LOWER.value:
                 return cls.PICO_THREE_BUTTON_RAISE_LOWER
+            case cls.PICO_TWO_BUTTON.value:
+                return cls.PICO_TWO_BUTTON
             case _:
-                raise LookupError(f"{str_literal} is not a valid pico remote type")
+                raise LookupError(
+                    f"{str_literal} is not a valid, supported pico remote type"
+                )
 
     @classmethod
     def values(cls) -> Iterable[str]:

--- a/src/pico_to_mqtt/caseta/model.py
+++ b/src/pico_to_mqtt/caseta/model.py
@@ -75,6 +75,7 @@ class ButtonState(Enum):
 
 
 class PicoRemoteType(StrEnum):
+    PICO_TWO_BUTTON = "Pico2Button"
     PICO_THREE_BUTTON_RAISE_LOWER = "Pico3ButtonRaiseLower"
 
     def as_str(self) -> str:

--- a/src/pico_to_mqtt/caseta/topology.py
+++ b/src/pico_to_mqtt/caseta/topology.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 from asyncio import Condition
-from typing import MutableMapping
+from typing import Mapping, Optional
 
 from pylutron_caseta.smartbridge import Smartbridge
 
@@ -10,6 +10,13 @@ from pico_to_mqtt.caseta.model import ButtonId, PicoRemote, PicoRemoteType
 from pico_to_mqtt.config import CasetaConfig
 
 LOGGER = logging.getLogger(__name__)
+
+
+class TopologyInitializationException(Exception):
+    """raised when someone tries to do something with a
+    topology that has not been connected and initialized"""
+
+    pass
 
 
 def default_bridge(caseta_config: CasetaConfig) -> Smartbridge:
@@ -31,7 +38,7 @@ class Topology:
         self._caseta_bridge: Smartbridge = caseta_bridge
         self._shutdown_condition = shutdown_condition
         self._button_tracker = button_tracker
-        self._remotes_by_id: MutableMapping[int, PicoRemote] = {}
+        self._remotes_by_id: Optional[Mapping[int, PicoRemote]]
 
     async def connect(self) -> None:
         LOGGER.info("connecting to caseta bridge")
@@ -56,6 +63,7 @@ class Topology:
             )
         }
 
+        remotes_by_id = {}
         for device_id, device in all_devices.items():
             # skip devices that are not remotes
             if device_id not in buttons_by_remote_id.keys():
@@ -72,7 +80,7 @@ class Topology:
             device_id_as_int = int(device_id)
             if device["type"] in PicoRemoteType.values():
                 device_type = PicoRemoteType.from_str(device["type"])
-                self._remotes_by_id[device_id_as_int] = PicoRemote(
+                remotes_by_id[device_id_as_int] = PicoRemote(
                     device_id_as_int,
                     device_type,
                     Topology._as_mqtt_friendly_name(device_name),
@@ -89,6 +97,7 @@ class Topology:
                     device["name"],
                     device["type"],
                 )
+        self._remotes_by_id = remotes_by_id
         LOGGER.info("done connecting to caseta bridge")
 
     @staticmethod
@@ -96,7 +105,14 @@ class Topology:
         return raw_name.lower().replace("_", "-").replace(" ", "-")
 
     def attach_callbacks(self):
-        for _remote_id, remote in self._remotes_by_id.items():
+        remotes_by_id = self._remotes_by_id
+
+        if remotes_by_id is None:
+            raise TopologyInitializationException(
+                "topology has not been initialized yet"
+            )
+
+        for _remote_id, remote in remotes_by_id.items():
             for button_id, button in remote.buttons_by_button_id.items():
                 self._caseta_bridge.add_button_subscriber(
                     str(button_id),

--- a/src/pico_to_mqtt/config.py
+++ b/src/pico_to_mqtt/config.py
@@ -25,6 +25,7 @@ class CasetaConfig:
     path_to_caseta_client_cert: Path
     path_to_caseta_client_key: Path
     path_to_caseta_client_ca: Path
+    caseta_bridge_refresh_interval_sec: int = 60
 
 
 @ts.settings(frozen=True)

--- a/src/pico_to_mqtt/event_handler.py
+++ b/src/pico_to_mqtt/event_handler.py
@@ -44,6 +44,7 @@ class EventHandler:
             "button_id": event.button_id.name,
             "area": event.remote.area_name,
             "action": event.button_event.name,
+            "remote_type": event.remote.type,
         }
         payload_str = json.dumps(payload)
         try:

--- a/src/pico_to_mqtt/main.py
+++ b/src/pico_to_mqtt/main.py
@@ -120,8 +120,9 @@ async def main_loop(configuration: AllConfig):
             else:
                 LOGGER.info(
                     "the new topology is the same as the old topology. "
-                    "nothing to do here"
+                    "closing the new topology instance, since we won't need it anymore"
                 )
+                asyncio.create_task(new_topology.close())
 
             wait_for_caseta_bridge_refresh_interval_task = asyncio.create_task(
                 asyncio.sleep(
@@ -144,7 +145,8 @@ async def main_loop(configuration: AllConfig):
                     {"message": "shutdown condition received"}
                 )
                 return
-
+            else:
+                wait_for_shutdown_condition_task.cancel()
 
 async def sleep_for_three_seconds() -> None:
     await asyncio.sleep(3)

--- a/src/pico_to_mqtt/main.py
+++ b/src/pico_to_mqtt/main.py
@@ -84,6 +84,7 @@ async def main_loop(configuration: AllConfig):
     mqtt_client = new_mqtt_client(
         configuration.mqtt_config, configuration.mqtt_credentials
     )
+
     async with mqtt_client as context_managed_mqtt_client:
         caseta_event_handler = EventHandler(
             context_managed_mqtt_client, shutdown_condition
@@ -94,19 +95,56 @@ async def main_loop(configuration: AllConfig):
             configuration.button_watcher_config,
             datetime.datetime.now,
         )
-        topology = Topology(
-            default_bridge(configuration.caseta_config),
-            shutdown_condition,
-            button_tracker,
-        )
-        await topology.connect()
-        topology.attach_callbacks()
-        async with shutdown_condition:
-            await shutdown_condition.wait()
-
-            asyncio.get_running_loop().call_exception_handler(
-                {"message": "shutdown condition received"}
+        current_topology: Optional[Topology] = None
+        while True:
+            new_topology = Topology(
+                default_bridge(configuration.caseta_config),
+                shutdown_condition,
+                button_tracker,
             )
+            await new_topology.connect()
+
+            if not current_topology:
+                LOGGER.info("connecting an initial topology instance")
+                current_topology = new_topology
+                current_topology.attach_callbacks()
+            elif current_topology.remotes_by_id != new_topology.remotes_by_id:
+                LOGGER.info(
+                    "new topoology differs from existing topology. "
+                    "swapping out the old topology"
+                )
+                old_topology = current_topology
+                current_topology = new_topology
+                current_topology.attach_callbacks()
+                asyncio.create_task(old_topology.close())
+            else:
+                LOGGER.info(
+                    "the new topology is the same as the old topology. "
+                    "nothing to do here"
+                )
+
+            async with shutdown_condition:
+                sleep_for_three_seconds_task = asyncio.create_task(
+                    sleep_for_three_seconds()
+                )
+                wait_for_shutdown_condition_task = asyncio.create_task(
+                    shutdown_condition.wait()
+                )
+                finished_tasks, _unfinished_tasks = await asyncio.wait(
+                    [sleep_for_three_seconds_task, wait_for_shutdown_condition_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if wait_for_shutdown_condition_task in finished_tasks:
+                    asyncio.get_running_loop().call_exception_handler(
+                        {"message": "shutdown condition received"}
+                    )
+                    return
+                
+
+
+async def sleep_for_three_seconds() -> None:
+    await asyncio.sleep(3)
 
 
 def main():

--- a/src/pico_to_mqtt/main.py
+++ b/src/pico_to_mqtt/main.py
@@ -118,7 +118,7 @@ async def main_loop(configuration: AllConfig):
                 current_topology.attach_callbacks()
                 asyncio.create_task(old_topology.close())
             else:
-                LOGGER.info(
+                LOGGER.debug(
                     "the new topology is the same as the old topology. "
                     "closing the new topology instance, since we won't need it anymore"
                 )
@@ -147,9 +147,6 @@ async def main_loop(configuration: AllConfig):
                 return
             else:
                 wait_for_shutdown_condition_task.cancel()
-
-async def sleep_for_three_seconds() -> None:
-    await asyncio.sleep(3)
 
 
 async def wait_for_shutdown_condition(shutdown_condition: asyncio.Condition) -> None:

--- a/typings/pylutron_caseta/smartbridge.pyi
+++ b/typings/pylutron_caseta/smartbridge.pyi
@@ -236,6 +236,6 @@ class Smartbridge:
         """
         ...
 
-    async def close(self):  # -> None:
+    async def close(self) -> None:
         """Disconnect from the bridge."""
         ...


### PR DESCRIPTION
this let us add or update a pico remote and have picotomqtt eventually pick up the changes. I didn't see a way to subscribe to the smartbridge to listen for "something here changed" events, so I'm using a loop with a refresh interval to create a new topology, compare it with the existing one, and swap in the new topology if it's different from the existing one.

this also adds support for Pico2Button remotes by adding a _remote type_ field to the mqtt message payload.